### PR TITLE
Rearrange CODEOWNERS to trigger compliance bot.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dixahq/ios @dixahq/backend-io @dixahq/frontend-io
+* @dixahq/frontend-io @dixahq/backend-io @dixahq/ios


### PR DESCRIPTION
SOC2 compliance bot for vulnerabilities only looks up at the first owner to determine where to send alerts. Choosing frontend-io as the first option.