### PR TITLE
chore: reorder CODEOWNERS to put @dixahq/ios first

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dixahq/frontend-io @dixahq/backend-io @dixahq/ios
+* @dixahq/ios @dixahq/frontend-io @dixahq/backend-io


### PR DESCRIPTION
## Why

The utilities at `compliance-automation/` use the first codeowner listed as the primary reference for ownership. This repo is an iOS project, so `@dixahq/ios` should appear first.

## What changed

Moved `@dixahq/ios` to the front of the CODEOWNERS entry. Other owners are unchanged.