### PR TITLE
Align declared minimum iOS with the shipped binary (15.0)

### DIFF
--- a/DixaMessengerKit.podspec
+++ b/DixaMessengerKit.podspec
@@ -24,9 +24,9 @@ Pod::Spec.new do |s|
   s.author           = { 'andras' => 'ama@dixa.com' }
   s.source = { :http => "https://github.com/dixahq/ios-messenger/releases/download/#{s.version}/DixaMessenger.xcframework.zip" }
   s.vendored_frameworks = "DixaMessenger.xcframework"
-  s.ios.deployment_target = '16.0'
+  s.ios.deployment_target = '15.0'
   s.pod_target_xcconfig = {
-  'IPHONEOS_DEPLOYMENT_TARGET' => '16.0'
+  'IPHONEOS_DEPLOYMENT_TARGET' => '15.0'
   }
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "DixaMessenger",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v15)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Documentation fixes:
- min iOS version is now 15 (was 16)
- bumped the Package min to 15 to match the overall min. version supported (was 13)